### PR TITLE
Remove redundant variable and functions which could lead to compile fail

### DIFF
--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/Schema.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/Schema.java
@@ -25,7 +25,6 @@ public class Schema {
     private int status = 0;
     private String keysType;
     private List<Field> properties;
-    private String keysType;
 
     public Schema() {
         properties = new ArrayList<>();
@@ -57,14 +56,6 @@ public class Schema {
 
     public void setProperties(List<Field> properties) {
         this.properties = properties;
-    }
-
-    public String getKeysType() {
-        return keysType;
-    }
-
-    public void setKeysType(String keysType) {
-        this.keysType = keysType;
     }
 
     public void put(String name, String type, String comment, int scale, int precision, String aggregation_type) {


### PR DESCRIPTION
[ERROR] /root/dev-1.0.1/extension/doris-spark-connector/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/Schema.java:28: error: keysType is already defined as variable keysType
[INFO]     private String keysType;
[INFO]                    ^
[ERROR] one error found

[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /root/dev-1.0.1/extension/doris-spark-connector/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/Schema.java:[61,19] method getKeysType() is already defined in class org.apache.doris.spark.rest.models.Schema
[ERROR] /root/dev-1.0.1/extension/doris-spark-connector/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/Schema.java:[65,17] method setKeysType(java.lang.String) is already defined in class org.apache.doris.spark.rest.models.Schema
[INFO] 2 errors 
[INFO] -------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE