### PR TITLE
[fix] build.sh script --spark 2.3.4 --scala 2.11 parameters do not take effect

### DIFF
--- a/spark-doris-connector/build.sh
+++ b/spark-doris-connector/build.sh
@@ -56,15 +56,6 @@ if [ $# == 0 ] ; then
     usage
 fi
 
-eval set -- "$OPTS"
-
-. "${DORIS_HOME}"/env.sh
-
-# include custom environment variables
-if [[ -f ${DORIS_HOME}/custom_env.sh ]]; then
-    . "${DORIS_HOME}"/custom_env.sh
-fi
-
 BUILD_FROM_TAG=0
 SPARK_VERSION=0
 SCALA_VERSION=0
@@ -74,9 +65,18 @@ while true; do
         --scala) SCALA_VERSION=$2 ; shift 2 ;;
         --tag) BUILD_FROM_TAG=1 ; shift ;;
         --) shift ;  break ;;
-        *) echo "Internal error" ; exit 1 ;;
+        *) break ;;
     esac
 done
+
+eval set -- "$OPTS"
+
+. "${DORIS_HOME}"/env.sh
+
+# include custom environment variables
+if [[ -f ${DORIS_HOME}/custom_env.sh ]]; then
+    . "${DORIS_HOME}"/custom_env.sh
+fi
 
 # extract minor version:
 # eg: 3.1.2 -> 3
@@ -91,7 +91,7 @@ if [[ ${BUILD_FROM_TAG} -eq 1 ]]; then
     ${MVN_BIN} clean package
 else
     rm -rf ${ROOT}/output/
-    ${MVN_BIN} clean package -Dspark.version=${SPARK_VERSION} -Dscala.version=${SCALA_VERSION} -Dspark.minor.version=${SPARK_MINOR_VERSION}
+    ${MVN_BIN} clean package -Dspark.version=${SPARK_VERSION} -Dscala.version=${SCALA_VERSION} -Dspark.minor.version=${SPARK_MINOR_VERSION} -DskipTests
 fi
 
 mkdir ${ROOT}/output/


### PR DESCRIPTION
## Problem Summary:

1.The spark connector is compiled using the build.sh script, and the --spark 2.3.4 --scala 2.11 parameters do not take effect

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
